### PR TITLE
Added structs to create zincsearch requests bodies

### DIFF
--- a/server/email_search/model.go
+++ b/server/email_search/model.go
@@ -35,3 +35,26 @@ type EmailSearchResult struct {
 		} `json:"hits"`
 	} `json:"hits"`
 }
+
+type SearchDocumentsBody struct {
+	SearchType string                   `json:"search_type"`
+	SortFields []string                 `json:"sort_fields"`
+	From       int                      `json:"from"`
+	MaxResults int                      `json:"max_results"`
+	Query      SearchDocumentsQuery `json:"query"`
+	Source     []string                 `json:"_source"`
+	Highlight  Highlight                `json:"highlight"`
+}
+
+type SearchDocumentsQuery struct {
+	Term      string  `json:"term"`
+	Field     string  `json:"field"`
+	StartTime *string `json:"start_time,omitempty"`
+	EndTime   *string `json:"end_time,omitempty"`
+}
+
+type Highlight struct {
+	PreTags  []string                  `json:"pre_tags"`
+	PostTags []string                  `json:"post_tags"`
+	Fields   *map[string]interface{} `json:"fields,omitempty"`
+}

--- a/server/email_search/zincsearchRepo.go
+++ b/server/email_search/zincsearchRepo.go
@@ -23,28 +23,17 @@ func NewZincsearchRepository() Repo {
 
 // GetEmails implements Repo.
 func (z *ZincsearchRepo) GetEmails(ctx context.Context, filter string) (EmailSearchResponse, error) {
-	requestBody := map[string]interface{}{
-		"search_type": "matchphrase",
-		"query": map[string]interface{}{
-			"term":  filter,
-			"field": "content",
+	requestBody := SearchDocumentsBody{
+		SearchType: "matchphrase",
+		Query: SearchDocumentsQuery{
+			Term:  filter,
+			Field: "content",
 		},
-		"from":        0,
-		"max_results": 200,
-		"_source":     []string{},
-		"highlight": map[string]interface{}{
-			"pre_tags":  []string{"<strong>"},
-			"post_tags": []string{"</strong>"},
-			"fields": map[string]interface{}{
-				"title": map[string]interface{}{
-					"pre_tags":  []string{},
-					"post_tags": []string{},
-				},
-				"content": map[string]interface{}{
-					"pre_tags":  []string{},
-					"post_tags": []string{},
-				},
-			},
+		From:       0,
+		MaxResults: 200,
+		Highlight: Highlight{
+			PreTags:  []string{"<strong>"},
+			PostTags: []string{"<strong>"},
 		},
 	}
 


### PR DESCRIPTION
## Context 

The request body was created more dynamically and wasn't that easy to read. 
Now with the structs is easier to understand what the request body has and to assign values.